### PR TITLE
libstore: default to daemon even as root

### DIFF
--- a/src/libstore/store-api.cc
+++ b/src/libstore/store-api.cc
@@ -908,9 +908,7 @@ StoreType getStoreType(const std::string & uri, const std::string & stateDir)
     } else if (uri == "local" || hasPrefix(uri, "/")) {
         return tLocal;
     } else if (uri == "" || uri == "auto") {
-        if (access(stateDir.c_str(), R_OK | W_OK) == 0)
-            return tLocal;
-        else if (pathExists(settings.nixDaemonSocketFile))
+        if (pathExists(settings.nixDaemonSocketFile))
             return tDaemon;
         else
             return tLocal;


### PR DESCRIPTION
If the daemon exists, use it. Even if the user has write access to the
state dir.