### PR TITLE
introduce store without file system details

### DIFF
--- a/doc/manual/src/architecture/architecture.md
+++ b/doc/manual/src/architecture/architecture.md
@@ -37,7 +37,6 @@ The command line and Nix language are what users interact with most.
 ::: {.note}
 The Nix language itself does not have a notion of *packages* or *configurations*.
 As far as we are concerned here, the inputs and results of a derivation are just data.
-In practice this amounts to a set of files in a file system.
 :::
 
 Underlying these is the [Nix store](./store/store.md), a mechanism to keep track of build plans, data, and references between them.

--- a/doc/manual/src/architecture/store/objects.md
+++ b/doc/manual/src/architecture/store/objects.md
@@ -35,21 +35,6 @@ A bare file or symlink can be a root file system object.
 
 Symlinks pointing outside of their own root, or to a store object without a matching reference, are allowed, but might not function as intended.
 
-## Reference {#reference}
-
-A store object can reference other store objects.
-
-Nix stores have the *closure property*: for each store object in the store, all the store objects it references must also be in the store.
-
-Building, copying and deleting store objects must be done in a way that obeys this property:
-
-- Build results must only refer to store objects in the closure of the build inputs.
-
-- Store objects being copied must refer to objects already in the destination store.
-  Recursive copying must either proceed in dependency order or be atomic.
-
-- We can only safely delete unreferenced objects.
-
 ### Reference scanning
 
 While references could be arbitrary paths, Nix requires them to be store paths to ensure correctness.

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -15,7 +15,7 @@ Store objects are [immutable][immutable-object]: once created, they do not chang
 
 ## Reference
 
-References to store objects are [opaque][opaque-data-type], [unique identifiers][unique-identifier]:
+A store object reference is an [opaque][opaque-data-type], [unique identifier][unique-identifier]:
 The only way to obtain references is by adding or building store objects.
 A reference will always point to exactly one store object.
 

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -16,7 +16,7 @@ data StoreObject = StoreObject {
 
 A Nix store can *add*, *retrieve*, and *delete* store objects.
 
-It can *perform builds*, that is, create new store objects by transforming build inputs, using instructions from the build tasks, into build outputs.
+It can *perform builds*, that is, create new store objects by transforming build inputs into build outputs, using instructions from the build tasks.
 
 As it keeps track of references, it can [garbage-collect](https://en.m.wikipedia.org/wiki/Garbage_collection_(computer_science)) unused store objects.
 
@@ -57,9 +57,9 @@ Garbage collection will delete all store objects that cannot be reached from any
 
 ## Files and Processes
 
-Nix provides a mapping between its store model and the [Unix paradigm](https://en.m.wikipedia.org/wiki/Everything_is_a_file) on the interplay of [files and processes](https://en.m.wikipedia.org/wiki/File_descriptor).
+Nix provides a mapping between its store model and the [Unix paradigm](https://en.m.wikipedia.org/wiki/Everything_is_a_file) that governs the interplay of [files and processes](https://en.m.wikipedia.org/wiki/File_descriptor).
 
-Nix encodes immutable store objects and opaque identifiers as file system primitives: files, directories, and paths.
+Nix encodes immutable store objects and opaque identifiers as file system primitives: files and directories, and paths.
 That allows processes to resolve references contained in files and thus access the contents of store objects.
 
 ```

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -88,7 +88,7 @@ Adding, building, copying and deleting store objects must be done in a way that 
 
 - We can only safely delete store objects which are not reachable from any reference still in use.
 
-  Garbage collection will delete all store objects that cannot be reached from any reference in use.
+  Garbage collection will delete those store objects that cannot be reached from any reference in use.
 
   <!-- more details in section on garbage collection, link to it once it exists -->
 

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -52,15 +52,26 @@ References are [opaque][opaque-data-type], [unique identifiers][unique-identifie
 The only way to obtain references is by adding or building store objects.
 A reference will always point to exactly one store object.
 
-An added store object cannot have references, unless it is a build task.
+Nix stores have the *closure property*: for each store object in the store, all the store objects it references must also be in the store.
 
-Building a store object will add appropriate references, according to provided build instructions.
-These references can only come from declared build inputs, and are not known to build instructions a priori.
+Adding, building, copying and deleting store objects must be done in a way that obeys this property:
 
-A store object cannot be deleted as long as it is reachable from a reference still in use.
-Garbage collection will delete all store objects that cannot be reached from any reference in use.
+- A newly added store object cannot have references, unless it is a build task.
 
-<!-- more details in section on garbage collection, link to it once it exists -->
+- Build results must only refer to store objects in the closure of the build inputs.
+
+  Building a store object will add appropriate references, according to provided build instructions.
+  These references can only come from declared build inputs.
+
+- Store objects being copied must refer to objects already in the destination store.
+
+  Recursive copying must either proceed in dependency order or be atomic.
+
+- We can only safely delete store objects which are not reachable from any reference still in use.
+
+  Garbage collection will delete all store objects that cannot be reached from any reference in use.
+
+  <!-- more details in section on garbage collection, link to it once it exists -->
 
 [garbage-collection]: https://en.m.wikipedia.org/wiki/Garbage_collection_(computer_science)
 [immutable-object]: https://en.m.wikipedia.org/wiki/Immutable_object

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -18,7 +18,7 @@ A Nix store can *add*, *retrieve*, and *delete* store objects.
 
 It can *perform builds*, that is, create new store objects by transforming build inputs into build outputs, using instructions from the build tasks.
 
-As it keeps track of references, it can [garbage-collect](https://en.m.wikipedia.org/wiki/Garbage_collection_(computer_science)) unused store objects.
+As it keeps track of references, it can [garbage-collect][garbage-collection] unused store objects.
 
 ```haskell
 add    :: Store -> Data -> (Store, Reference)
@@ -30,9 +30,9 @@ build  :: Store -> Reference -> Maybe (Store, Reference)
 collectGarbage :: Store -> Store
 ```
 
-Store objects are [immutable](https://en.m.wikipedia.org/wiki/Immutable_object): once created, they do not change until they are deleted.
+Store objects are [immutable][immutable-object]: once created, they do not change until they are deleted.
 
-References are [opaque](https://en.m.wikipedia.org/wiki/Opaque_data_type), [unique identifiers](https://en.m.wikipedia.org/wiki/Unique_identifier):
+References are [opaque][opaque-data-type], [unique identifiers][unique-identifier]:
 The only way to obtain references is by adding or building store objects.
 A reference will always point to exactly one store object.
 
@@ -54,6 +54,11 @@ A store object cannot be deleted as long as it is reachable from a reference sti
 Garbage collection will delete all store objects that cannot be reached from any reference in use.
 
 <!-- more details in section on garbage collection, link to it once it exists -->
+
+[garbage-collection]: https://en.m.wikipedia.org/wiki/Garbage_collection_(computer_science)
+[immutable-object]: https://en.m.wikipedia.org/wiki/Immutable_object
+[opaque-data-type]: https://en.m.wikipedia.org/wiki/Opaque_data_type
+[unique-identifier]: https://en.m.wikipedia.org/wiki/Unique_identifier
 
 ## Files and Processes
 

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -102,6 +102,11 @@ Adding, building, copying and deleting store objects must be done in a way that 
 Nix maps between its store model and the [Unix paradigm][unix-paradigm] of [files and processes][file-descriptor], by encoding immutable store objects and opaque identifiers as file system primitives: files and directories, and paths.
 That allows processes to resolve references contained in files and thus access the contents of store objects.
 
+Store objects are therefore implemented as the pair of
+
+  - a *file system object* for data
+  - a set of *store paths* for references.
+
 [unix-paradigm]: https://en.m.wikipedia.org/wiki/Everything_is_a_file
 [file-descriptor]: https://en.m.wikipedia.org/wiki/File_descriptor
 
@@ -138,11 +143,6 @@ That allows processes to resolve references contained in files and thus access t
 |                         +------------+                          |
 +-----------------------------------------------------------------+
 ```
-
-Store objects are therefore implemented as the pair of
-
-  - a *file system object* for data
-  - a set of *store paths* for references.
 
 There exist different types of stores, which all follow this model.
 Examples:

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -88,10 +88,11 @@ Adding, building, copying and deleting store objects must be done in a way that 
 
 ## Files and Processes
 
-Nix provides a mapping between its store model and the [Unix paradigm](https://en.m.wikipedia.org/wiki/Everything_is_a_file) that governs the interplay of [files and processes](https://en.m.wikipedia.org/wiki/File_descriptor).
-
-Nix encodes immutable store objects and opaque identifiers as file system primitives: files and directories, and paths.
+Nix maps between its store model and the [Unix paradigm][unix-paradigm] of [files and processes][file-descriptor], by encoding immutable store objects and opaque identifiers as file system primitives: files and directories, and paths.
 That allows processes to resolve references contained in files and thus access the contents of store objects.
+
+[unix-paradigm]: https://en.m.wikipedia.org/wiki/Everything_is_a_file
+[file-descriptor]: https://en.m.wikipedia.org/wiki/File_descriptor
 
 ```
 +-----------------------------------------------------------------+

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -26,14 +26,20 @@ A Nix store can *add*, *retrieve*, and *delete* store objects.
                 [ data ]
                     |
                     V
-    [ store ] ---> add ----> [ store' ], [ reference ]
+    [ store ] ---> add ----> [ store' ]
+                    |
+                    V
+              [ reference ]
 
 <!-- -->
 
               [ reference ]
                     |
                     V
-    [ store ] ---> get ----> [ store object ]
+    [ store ] ---> get
+                    |
+                    V
+             [ store object ]
 
 <!-- -->
 
@@ -49,7 +55,12 @@ It can *perform builds*, that is, create new store objects by transforming build
               [ reference ]
                     |
                     V
-    [ store ] --> build --(maybe)--> [ store' ], [ reference' ]
+    [ store ] --> build
+                       \
+                      (maybe) --> [ store' ]
+                         |
+                         V
+                   [ reference ]
 
 
 As it keeps track of references, it can [garbage-collect][garbage-collection] unused store objects.

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -79,7 +79,7 @@ Adding, building, copying and deleting store objects must be done in a way that 
 
 - Build results must only refer to store objects in the closure of the build inputs.
 
-  Building a store object will add appropriate references, according to provided build instructions.
+  Building a store object will add appropriate references, according to the build task.
   These references can only come from declared build inputs.
 
 - Store objects being copied must refer to objects already in the destination store.

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -26,7 +26,7 @@ A Nix store can *add*, *retrieve*, and *delete* store objects.
                 [ data ]
                     |
                     V
-    [ store ] ---> add ----> [ store' ] [ reference ]
+    [ store ] ---> add ----> [ store' ], [ reference ]
 
 <!-- -->
 
@@ -49,7 +49,7 @@ It can *perform builds*, that is, create new store objects by transforming build
               [ reference ]
                     |
                     V
-    [ store ] --> build --(maybe)--> [ store' ] [ reference' ]
+    [ store ] --> build --(maybe)--> [ store' ], [ reference' ]
 
 
 As it keeps track of references, it can [garbage-collect][garbage-collection] unused store objects.

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -2,8 +2,8 @@
 
 A Nix store is a collection of *store objects*.
 
-Store objects can hold arbitrary *data* and *references* to one another.
-Nix makes no distinction if they are used as build inputs, build results, or build tasks.
+A store object can hold arbitrary *data* and *references* to other store objects.
+Nix makes no distinction if store objects are used as build inputs, build results, or build tasks.
 
 ```haskell
 data Store = Set StoreObject

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -2,12 +2,24 @@
 
 A Nix store is a collection of *store objects*.
 
+## Store Object
+
 A store object can hold
 
 - arbitrary *data*
 - *references* to other store objects.
 
 Nix makes no distinction if store objects are build inputs, build results, or build tasks.
+
+Store objects are [immutable][immutable-object]: once created, they do not change until they are deleted.
+
+## Reference
+
+References to store objects are [opaque][opaque-data-type], [unique identifiers][unique-identifier]:
+The only way to obtain references is by adding or building store objects.
+A reference will always point to exactly one store object.
+
+## Operations
 
 A Nix store can *add*, *retrieve*, and *delete* store objects.
 
@@ -46,11 +58,7 @@ As it keeps track of references, it can [garbage-collect][garbage-collection] un
     [ store ] --> collect garbage --> [ store' ]
 
 
-Store objects are [immutable][immutable-object]: once created, they do not change until they are deleted.
-
-References are [opaque][opaque-data-type], [unique identifiers][unique-identifier]:
-The only way to obtain references is by adding or building store objects.
-A reference will always point to exactly one store object.
+## Closure
 
 Nix stores have the *closure property*: for each store object in the store, all the store objects it references must also be in the store.
 

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -39,7 +39,7 @@ A reference will always point to exactly one store object.
 An added store object cannot have references, unless it is a build task.
 
 Building a store object will add appropriate references, according to provided build instructions.
-These references can only come from declared build inputs, and are not known by build instructions a priori.
+These references can only come from declared build inputs, and are not known to build instructions a priori.
 
 ```haskell
 data Data = Data | Task BuildTask
@@ -55,14 +55,59 @@ Garbage collection will delete all store objects that cannot be reached from any
 
 <!-- more details in section on garbage collection, link to it once it exists -->
 
+## Files and Processes
+
+Nix provides a mapping between its store model and the [Unix paradigm](https://en.m.wikipedia.org/wiki/Everything_is_a_file) on the interplay of [files and processes](https://en.m.wikipedia.org/wiki/File_descriptor).
+
+Nix encodes immutable store objects and opaque identifiers as file system primitives: files, directories, and paths.
+That allows processes to resolve references contained in files and thus access the contents of store objects.
+
+```
++-----------------------------------------------------------------+
+| Nix                                                             |
+|                  [ commmand line interface ]------,             |
+|                               |                   |             |
+|                           evaluates               |             |
+|                               |                manages          |
+|                               V                   |             |
+|                  [ configuration language  ]      |             |
+|                               |                   |             |
+| +-----------------------------|-------------------V-----------+ |
+| | store                  evaluates to                         | |
+| |                             |                               | |
+| |             referenced by   V       builds                  | |
+| |  [ build input ] ---> [ build plan ] ---> [ build result ]  | |
+| |         ^                                        |          | |
+| +---------|----------------------------------------|----------+ |
++-----------|----------------------------------------|------------+
+            |                                        |
+    file system object                          store path
+            |                                        |
++-----------|----------------------------------------|------------+
+| operating system        +------------+             |            |
+|           '------------ |            | <-----------'            |
+|                         |    file    |                          |
+|                     ,-- |            | <-,                      |
+|                     |   +------------+   |                      |
+|          execute as |                    | read, write, execute |
+|                     |   +------------+   |                      |
+|                     '-> |  process   | --'                      |
+|                         +------------+                          |
++-----------------------------------------------------------------+
+```
+
+Store objects are therefore implemented as the pair of
+
+  - a *file system object* for data
+  - a set of *store paths* for references.
+
 There exist different types of stores, which all follow this model.
 Examples:
 - store on the local file system
 - remote store accessible via SSH
 - binary cache store accessible via HTTP
 
-Every store with a file system representation has a *store directory*, which contains that store’s objects accessible through [store paths](paths.md).
-The store directory defaults to `/nix/store`, but is in principle arbitrary.
+Every store ultimately has to make store objects accessible to processes through the file system.
 
 ## A [Rosetta stone](https://en.m.wikipedia.org/wiki/Rosetta_Stone) for build system terminology
 

--- a/doc/manual/src/architecture/store/store.md
+++ b/doc/manual/src/architecture/store/store.md
@@ -150,7 +150,7 @@ Examples:
 - remote store accessible via SSH
 - binary cache store accessible via HTTP
 
-Every store ultimately has to make store objects accessible to processes through the file system.
+To make store objects accessible to processes, stores ultimately have to expose store objects through the file system.
 
 ## A [Rosetta stone](https://en.m.wikipedia.org/wiki/Rosetta_Stone) for build system terminology
 


### PR DESCRIPTION
this leaves open implementation details, especially about store paths and file system objects, and allows explaining them together were it is more appropriate.