### PR TITLE
revert to "build plan" in top-level overview

### DIFF
--- a/doc/manual/src/architecture/architecture.md
+++ b/doc/manual/src/architecture/architecture.md
@@ -8,19 +8,22 @@ It should help users understand why Nix behaves as it does, and it should help d
 Nix consists of hierarchical [layers](https://en.m.wikipedia.org/wiki/Multitier_architecture#Layers).
 
 ```
-                   [ commmand line interface ]--------+
-                                |                     |
-                                | evaluates           | manages
-                                V                     |
-                   [ configuration language  ]        |
-                                |                     |
-+-------------------------------|---------------------V-----------+
-| store                         | evaluates to                    |
-|  .............................V...............................  |
-|  : build plan                                                :  |
-|  :            referenced by           builds                 :  |
-|  :  [ build input ] --> [ build task ] --> [ build result ]  :  |
-|  :...........................................................:  |
++-----------------------------------------------------------------+
+| Nix                                                             |
+|                  [ commmand line interface ]------,             |
+|                               |                   |             |
+|                           evaluates               |             |
+|                               |                manages          |
+|                               V                   |             |
+|                  [ configuration language  ]      |             |
+|                               |                   |             |
+| +-----------------------------|-------------------V-----------+ |
+| | store                  evaluates to                         | |
+| |                             |                               | |
+| |             referenced by   V       builds                  | |
+| |  [ build input ] ---> [ build plan ] ---> [ build result ]  | |
+| |                                                             | |
+| +-------------------------------------------------------------+ |
 +-----------------------------------------------------------------+
 ```
 

--- a/doc/manual/src/architecture/architecture.md
+++ b/doc/manual/src/architecture/architecture.md
@@ -30,7 +30,9 @@ Nix consists of [hierarchical layers][layer-architecture].
 At the top is the [command line interface](../command-ref/command-ref.md), translating from invocations of Nix executables to interactions with the underlying layers.
 
 Below that is the [Nix expression language](../expressions/expression-language.md), a [purely functional][purely-functional-programming] configuration language.
-It is used to compose expressions which ultimately evaluate to self-contained *build plans*, made up *build tasks* used to derive *build results* from referenced *build inputs*.
+It is used to compose expressions which ultimately evaluate to self-contained *build plans*, used to derive *build results* from referenced *build inputs*.
+
+The command line and Nix language are what users interact with most.
 
 ::: {.note}
 The Nix language itself does not have a notion of *packages* or *configurations*.
@@ -38,10 +40,9 @@ As far as we are concerned here, the inputs and results of a derivation are just
 In practice this amounts to a set of files in a file system.
 :::
 
-The command line and Nix language are what users interact with most.
+Underlying these is the [Nix store](./store/store.md), a mechanism to keep track of build plans, data, and references between them.
+It can also execute build plans to produce new data.
 
-Underlying these is the [Nix store](./store/store.md), a mechanism to keep track of build tasks, data, and references between them.
-It can also execute *build instructions*, captured in the build tasks, to produce new data.
 
 [layer-architecture]: https://en.m.wikipedia.org/wiki/Multitier_architecture#Layers
 [purely-functional-programming]: https://en.m.wikipedia.org/wiki/Purely_functional_programming

--- a/doc/manual/src/architecture/architecture.md
+++ b/doc/manual/src/architecture/architecture.md
@@ -5,7 +5,7 @@ It should help users understand why Nix behaves as it does, and it should help d
 
 ## Overview
 
-Nix consists of hierarchical [layers](https://en.m.wikipedia.org/wiki/Multitier_architecture#Layers).
+Nix consists of [hierarchical layers][layer-architecture].
 
 ```
 +-----------------------------------------------------------------+
@@ -29,7 +29,7 @@ Nix consists of hierarchical [layers](https://en.m.wikipedia.org/wiki/Multitier_
 
 At the top is the [command line interface](../command-ref/command-ref.md), translating from invocations of Nix executables to interactions with the underlying layers.
 
-Below that is the [Nix expression language](../expressions/expression-language.md), a [purely functional](https://en.m.wikipedia.org/wiki/Purely_functional_programming) configuration language.
+Below that is the [Nix expression language](../expressions/expression-language.md), a [purely functional][purely-functional-programming] configuration language.
 It is used to compose expressions which ultimately evaluate to self-contained *build plans*, made up *build tasks* used to derive *build results* from referenced *build inputs*.
 
 ::: {.note}
@@ -43,3 +43,5 @@ The command line and Nix language are what users interact with most.
 Underlying these is the [Nix store](./store/store.md), a mechanism to keep track of build tasks, data, and references between them.
 It can also execute *build instructions*, captured in the build tasks, to produce new data.
 
+[layer-architecture]: https://en.m.wikipedia.org/wiki/Multitier_architecture#Layers
+[purely-functional-programming]: https://en.m.wikipedia.org/wiki/Purely_functional_programming


### PR DESCRIPTION
do not introduce build tasks yet, that is the next level of detail.

@Ericson2314 you proposed this in the first place, and after thinking it through once again, I agree.

that way we leave room to explain and display the relation of build tasks separately.